### PR TITLE
add "blended little endian"

### DIFF
--- a/src/jmh/java/me/steinborn/varintshowdown/VarIntWriterBenchmark.java
+++ b/src/jmh/java/me/steinborn/varintshowdown/VarIntWriterBenchmark.java
@@ -84,6 +84,14 @@ public class VarIntWriterBenchmark {
 
   @Benchmark
   @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+  public void blendedLEVarintWrite(BlendedLEVarintState state) {
+    for (int number : numbers) {
+      state.write(number);
+    }
+  }
+
+  @Benchmark
+  @CompilerControl(CompilerControl.Mode.DONT_INLINE)
   public void lucky5VarintWrite(Lucky5VarintState state) {
     for (int number : numbers) {
       state.write(number);

--- a/src/jmh/java/me/steinborn/varintshowdown/res/BlendedLEVarIntWriter.java
+++ b/src/jmh/java/me/steinborn/varintshowdown/res/BlendedLEVarIntWriter.java
@@ -1,0 +1,31 @@
+package me.steinborn.varintshowdown.res;
+
+import io.netty.buffer.ByteBuf;
+
+public class BlendedLEVarIntWriter implements VarIntWriter {
+
+  @Override
+  public void write(ByteBuf buf, int value) {
+    if ((value & (0xFFFFFFFF << 7)) == 0) {
+      buf.writeByte(value);
+      return;
+    }
+    int a = (value & 0xFF) | ((value << 1) & 0xFF00);
+    if ((value & (0xFFFFFFFF << 14)) == 0) {
+      buf.writeShortLE(a | 0x80);
+    } else {
+      a |= (((value << 2) & 0xFF0000));
+      if ((value & (0xFFFFFFFF << 21)) == 0) {
+        buf.writeMediumLE(a | 0x8080);
+      } else {
+        a |= (((value << 3) & 0xFF000000));
+        if ((value & (0xFFFFFFFF << 28)) == 0) {
+          buf.writeIntLE(a | 0x808080);
+        } else {
+          buf.writeIntLE(a | 0x80808080);
+          buf.writeByte(value >>> 28);
+        }
+      }
+    }
+  }
+}

--- a/src/jmh/java/me/steinborn/varintshowdown/states/BlendedLEVarintState.java
+++ b/src/jmh/java/me/steinborn/varintshowdown/states/BlendedLEVarintState.java
@@ -1,0 +1,31 @@
+package me.steinborn.varintshowdown.states;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import me.steinborn.varintshowdown.res.BlendedLEVarIntWriter;
+import me.steinborn.varintshowdown.res.VarIntWriter;
+import org.openjdk.jmh.annotations.*;
+
+@State(Scope.Benchmark)
+public class BlendedLEVarintState {
+
+  private ByteBuf buf;
+  private VarIntWriter varIntWriter;
+
+  @Setup(Level.Trial)
+  public void setup() {
+    buf = Unpooled.directBuffer(5);
+    varIntWriter = new BlendedLEVarIntWriter();
+  }
+
+  @TearDown(Level.Trial)
+  public void tearDown() {
+    buf.release();
+  }
+
+  public void write(int value) {
+    varIntWriter.write(buf, value);
+    buf.clear();
+  }
+
+}


### PR DESCRIPTION
tested on my pc about 10 times and got similar results
```
Benchmark                                                        Mode  Cnt      Score       Error  Units
VarIntWriterBenchmark.blendedLEVarintWrite                      thrpt    5  78002.356 ± 11630.597  ops/s
VarIntWriterBenchmark.blendedVarintWrite                        thrpt    5  64156.372 ±  9307.778  ops/s
VarIntWriterBenchmark.lucky5VarintWrite                         thrpt    5  58445.796 ± 12179.340  ops/s
VarIntWriterBenchmark.oldVelocityVarintWrite                    thrpt    5  25118.362 ±  2492.646  ops/s
VarIntWriterBenchmark.smartNoDataDependencyUnrolledVarintWrite  thrpt    5  46349.077 ±  1839.195  ops/s
VarIntWriterBenchmark.smartUnrolledVarintWrite                  thrpt    5  42599.930 ±  2381.405  ops/s
VarIntWriterBenchmark.startinVarintWrite                        thrpt    5  20945.823 ±  1292.218  ops/s
VarIntWriterBenchmark.unrolledVarintWrite                       thrpt    5  22348.974 ±  3996.830  ops/s
```
i guess ByteBuf's writeXxxLE methods are faster when the current architecture is little-endian

~~i also tried jdk.incubator.vector in jdk21 but got ~5000 ops/s..~~